### PR TITLE
PI: Fix loop index data type

### DIFF
--- a/PI/pwa-acc-offload/pi.c
+++ b/PI/pwa-acc-offload/pi.c
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
     #pragma acc parallel
     {
     #pragma acc loop reduction(+: sum)
-    for (int i = 0; i < N; i++) {
+    for (unsigned long i = 0; i < N; i++) {
         double x = (i + 0.5) / N;
         sum += sqrt(1 - x * x);
     }

--- a/PI/pwa-omp-multi/pi.c
+++ b/PI/pwa-omp-multi/pi.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     #pragma omp parallel default(none) shared(N, sum)
     {
     #pragma omp for reduction(+: sum) schedule(auto)
-    for (int i = 0; i < N; i++) {
+    for (unsigned long i = 0; i < N; i++) {
         double x = (i + 0.5) / N;
         sum += sqrt(1 - x * x);
     }

--- a/PI/serial/pi.c
+++ b/PI/serial/pi.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
     double out_result;
 
     double sum = 0.0;
-    for (int i = 0; i < N; i++) {
+    for (unsigned long i = 0; i < N; i++) {
         double x = (i + 0.5) / N;
         sum += sqrt(1 - x * x);
     }


### PR DESCRIPTION
The data type of the loop index variable was not correct.

 Loop index -> int, while N -> unsigned long.
 If (N > INT_MAX), the code would not work as expected.