### PR TITLE
Remove MbedTLS script last clean

### DIFF
--- a/benchmark-mbedTLS-vector.sh
+++ b/benchmark-mbedTLS-vector.sh
@@ -5,6 +5,16 @@ for cmd in git cmake ninja printf pwreport pwdirectives; do
     command -v $cmd >/dev/null 2>&1 || { printf >&2 "$cmd is required but it's not installed. Aborting."; exit 1; }
 done
 
+# Check current directory
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  : # This is a valid git repository
+else
+  : # this is not a git repository
+  printf "Invalid git directory.\n"
+  printf "Please, clone directly the repository from https://github.com/teamappentra/performance-demos.git \n"
+  exit;
+fi
+
 # Print CPU information if the command is available
 if command -v lscpu >/dev/null 2>&1; then
     lscpu

--- a/benchmark-mbedTLS-vector.sh
+++ b/benchmark-mbedTLS-vector.sh
@@ -192,9 +192,4 @@ printf "vectorized done\n"
 
 #===============================================================================
 
-printf "\nCleaning the build . . .\n"
-
-git restore library/
-rm -rf build buildVec
-
 printf "\nDone.\n"


### PR DESCRIPTION
The script was cleaning everyghing at the end of its execution, which made the user unable to get the compile_commands.json and the optimized source files.